### PR TITLE
Persist access token across the session

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,11 @@ import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
 const App = props => (
   <Router>
     <Switch>
-      <Route path='/track' render={props => <TrackContainer {...props} />} />
+      <Route
+        exact
+        path='/track'
+        render={props => <TrackContainer {...props} />}
+      />
       <Route path='/' component={Home} />
       <Route exact path='/search' component={Search} />
     </Switch>

--- a/src/Search.js
+++ b/src/Search.js
@@ -6,7 +6,6 @@ import { searchTracks } from './services/searchTracks'
 import { PageContainer, Page } from './components/styled-components/Page/Page'
 import { LargeText } from './components/styled-components/Text/LargeText'
 import { MediumText } from './components/styled-components/Text/MediumText'
-import { TrackContainer } from './components/container-components/TrackContainer'
 
 const baseUrl = 'https://api.spotify.com/v1/search?q='
 export class Search extends React.Component {
@@ -20,16 +19,16 @@ export class Search extends React.Component {
   }
 
   componentDidMount () {
-    sessionStorage.setItem('accessToken', this.props.hashParams.access_token)
+    this.setState({ accessToken: localStorage.getItem('accessToken') })
   }
 
   handleSubmit = e => {
     e.preventDefault()
     e.stopPropagation()
-    this.setState({ accessToken: this.props.hashParams.access_token })
-
-    const uri = `${baseUrl}${encodeURIComponent(this.state.value)}&type=track`
-    searchTracks(uri, this.props.hashParams.access_token, this.collectResults)
+    searchTracks(
+      `${baseUrl}${encodeURIComponent(this.state.value)}&type=track`,
+      this.collectResults
+    )
   }
 
   collectResults = items => {

--- a/src/components/container-components/Home.js
+++ b/src/components/container-components/Home.js
@@ -17,23 +17,21 @@ class Home extends React.Component {
   state = {
     isLoggedIn: this.props.isLoggedIn,
     toSearch: this.props.toSearch,
-    hashParams: ''
+    accessToken: null
   }
 
   componentDidMount () {
     if (this.props.history.location.pathname === '/callback/') {
-      this.setState({
-        isLoggedIn: true,
-        toSearch: true,
-        hashParams: hashCredentials()
-      })
+      const hashParams = hashCredentials()
+      this.setState({ accessToken: hashParams.access_token })
+      localStorage.setItem('accessToken', hashParams.access_token)
     }
   }
 
   render () {
-    const { isLoggedIn, toSearch, hashParams } = this.state
-    if (isLoggedIn && toSearch) {
-      return <Search {...this.props} hashParams={hashParams} />
+    const { accessToken } = this.state
+    if (accessToken) {
+      return <Search {...this.props} />
     } else {
       return (
         <PageContainer>

--- a/src/services/getAudioAnalysis.js
+++ b/src/services/getAudioAnalysis.js
@@ -6,7 +6,7 @@ export const getAudioAnalysis = (callback, id) => {
   axios
     .get(uri, {
       headers: {
-        Authorization: 'Bearer ' + sessionStorage.getItem('accessToken')
+        Authorization: 'Bearer ' + localStorage.getItem('accessToken')
       }
     })
     .then(response => {

--- a/src/services/searchTracks.js
+++ b/src/services/searchTracks.js
@@ -1,10 +1,10 @@
 import axios from 'axios'
 
-export const searchTracks = (uri, accessToken, collectResults, tracks) => {
+export const searchTracks = (uri, collectResults) => {
   axios
     .get(uri, {
       headers: {
-        Authorization: 'Bearer ' + accessToken
+        Authorization: 'Bearer ' + localStorage.getItem('accessToken')
       }
     })
     .then(response => {


### PR DESCRIPTION
Fixes #7 

## Purpose
I was passing the access token down as props rather than storing it in local storage, which was causing some unusual behavior and undesired behavior. The user had to log in much too frequently.

## Approach
Now, the user only needs to log in when the token expires or for the first time that they use the application.
